### PR TITLE
feat: add local-first To-do widget (multi-list, localStorage)

### DIFF
--- a/.openhands/TASKS.md
+++ b/.openhands/TASKS.md
@@ -1,13 +1,15 @@
 # Task List
 
-1. 🔄 Scaffold React + TypeScript app with Vite in current repo and set up Tailwind CSS
-Create Vite project in app/ directory, install dependencies, configure Tailwind (init, content, base CSS).
-2. ⏳ Implement base dashboard layout and Clock widget
-Create simple grid layout, add a live clock/date component.
-3. ⏳ Configure Vite dev server for this environment
-Host 0.0.0.0, port 12000, allowedHosts true, CORS enabled, strictPort true.
-4. ⏳ Run dev server and verify it serves the dashboard
-Start on port 12000 and ensure it’s reachable.
-5. ⏳ Commit changes
-Commit with message and Co-authored-by trailer.
+1. ✅ Create new branch from main for To-do feature
+feat/todo-widget created and checked out
+2. 🔄 Implement local-first To-do library (types, load/save)
+
+3. ⏳ Build Todo widget UI (add, toggle, delete, clear completed, multi-list)
+
+4. ⏳ Integrate Todo widget into App grid
+
+5. ⏳ Type-check/build locally and fix any issues
+
+6. ⏳ Commit and push new feature branch to GitHub
+
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,6 +3,7 @@ import Calendar from './widgets/Calendar'
 
 import Weather from './widgets/Weather'
 import PhotoSlideshow from './widgets/PhotoSlideshow'
+import Todo from './widgets/Todo'
 
 
 function App() {
@@ -20,6 +21,9 @@ function App() {
         </div>
         <div className="col-span-2 row-span-2 rounded-xl p-0">
           <PhotoSlideshow />
+        </div>
+        <div className="col-span-2 row-span-2 bg-slate-800 rounded-xl p-4">
+          <Todo />
         </div>
         <div className="col-span-4 row-span-1 bg-slate-800 rounded-xl p-4">
           <Calendar />

--- a/app/src/lib/todo.ts
+++ b/app/src/lib/todo.ts
@@ -1,0 +1,80 @@
+export type TodoItem = { id: string; text: string; done: boolean; updatedAt: number }
+export type TodoList = { id: string; name: string; items: TodoItem[] }
+export type TodoState = { lists: TodoList[]; activeListId: string }
+
+const STORAGE_KEY = 'fam-bam-todo'
+
+export function now() { return Date.now() }
+
+export function uid(prefix = '') {
+  return prefix + Math.random().toString(36).slice(2, 8) + '-' + Date.now().toString(36)
+}
+
+export function defaultState(): TodoState {
+  const list1: TodoList = { id: uid('list-'), name: 'Family', items: [] }
+  const list2: TodoList = { id: uid('list-'), name: 'Groceries', items: [] }
+  return { lists: [list1, list2], activeListId: list1.id }
+}
+
+export function loadState(): TodoState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return defaultState()
+    const parsed = JSON.parse(raw)
+    if (!parsed || !Array.isArray(parsed.lists)) return defaultState()
+    return parsed as TodoState
+  } catch {
+    return defaultState()
+  }
+}
+
+export function saveState(state: TodoState) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  } catch {}
+}
+
+export function addList(state: TodoState, name: string): TodoState {
+  const list: TodoList = { id: uid('list-'), name, items: [] }
+  return { ...state, lists: [...state.lists, list], activeListId: list.id }
+}
+
+export function renameList(state: TodoState, listId: string, name: string): TodoState {
+  return { ...state, lists: state.lists.map(l => l.id === listId ? { ...l, name } : l) }
+}
+
+export function removeList(state: TodoState, listId: string): TodoState {
+  if (state.lists.length <= 1) return state
+  const lists = state.lists.filter(l => l.id !== listId)
+  const activeListId = state.activeListId === listId ? lists[0].id : state.activeListId
+  return { ...state, lists, activeListId }
+}
+
+export function setActive(state: TodoState, listId: string): TodoState {
+  if (!state.lists.some(l => l.id === listId)) return state
+  return { ...state, activeListId: listId }
+}
+
+export function addItem(state: TodoState, listId: string, text: string): TodoState {
+  const item: TodoItem = { id: uid('item-'), text: text.trim(), done: false, updatedAt: now() }
+  if (!item.text) return state
+  return { ...state, lists: state.lists.map(l => l.id === listId ? { ...l, items: [item, ...l.items] } : l) }
+}
+
+export function toggleItem(state: TodoState, listId: string, itemId: string): TodoState {
+  return {
+    ...state,
+    lists: state.lists.map(l => l.id === listId ? {
+      ...l,
+      items: l.items.map(it => it.id === itemId ? { ...it, done: !it.done, updatedAt: now() } : it)
+    } : l)
+  }
+}
+
+export function removeItem(state: TodoState, listId: string, itemId: string): TodoState {
+  return { ...state, lists: state.lists.map(l => l.id === listId ? { ...l, items: l.items.filter(it => it.id !== itemId) } : l) }
+}
+
+export function clearCompleted(state: TodoState, listId: string): TodoState {
+  return { ...state, lists: state.lists.map(l => l.id === listId ? { ...l, items: l.items.filter(it => !it.done) } : l) }
+}

--- a/app/src/widgets/Todo.tsx
+++ b/app/src/widgets/Todo.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { addItem, addList, clearCompleted, loadState, removeItem, removeList, renameList, saveState, setActive, toggleItem, type TodoState } from '../lib/todo'
+
+export default function TodoWidget() {
+  const [state, setState] = React.useState<TodoState>(() => loadState())
+  const [text, setText] = React.useState('')
+  const [newListName, setNewListName] = React.useState('')
+
+  React.useEffect(() => { saveState(state) }, [state])
+
+  const active = state.lists.find(l => l.id === state.activeListId)!
+
+  function onAdd(e: React.FormEvent) {
+    e.preventDefault()
+    setState(s => addItem(s, s.activeListId, text))
+    setText('')
+  }
+
+  return (
+    <div className="h-full w-full flex flex-col">
+      {/* List Tabs */}
+      <div className="flex gap-2 mb-3 overflow-x-auto">
+        {state.lists.map(l => (
+          <button key={l.id} onClick={() => setState(s => setActive(s, l.id))} className={`px-3 py-1 rounded-full text-sm whitespace-nowrap ${l.id===state.activeListId? 'bg-sky-600 text-white':'bg-slate-700 text-slate-100'}`}>{l.name}</button>
+        ))}
+        <div className="flex items-center gap-2">
+          <input value={newListName} onChange={e=>setNewListName(e.target.value)} placeholder="New list" className="bg-slate-800 text-slate-100 px-2 py-1 rounded border border-slate-700"/>
+          <button onClick={()=> { if(newListName.trim()){ setState(s=>addList(s, newListName.trim())); setNewListName('') } }} className="px-2 py-1 bg-emerald-600 rounded text-white">Add</button>
+        </div>
+      </div>
+
+      {/* Add form */}
+      <form onSubmit={onAdd} className="flex gap-2 mb-3">
+        <input autoFocus value={text} onChange={e=>setText(e.target.value)} placeholder="Add a task" className="flex-1 bg-slate-800 text-slate-100 px-3 py-2 rounded border border-slate-700"/>
+        <button className="px-3 py-2 bg-sky-600 rounded text-white">Add</button>
+      </form>
+
+      {/* Items */}
+      <div className="flex-1 overflow-auto rounded bg-slate-800 p-2">
+        {active.items.length === 0 ? (
+          <div className="text-slate-400 text-center py-10">No items yet</div>
+        ) : (
+          <ul className="space-y-2">
+            {active.items.map(it => (
+              <li key={it.id} className="flex items-center gap-3 bg-slate-900/60 rounded px-3 py-2">
+                <input type="checkbox" checked={it.done} onChange={()=> setState(s=>toggleItem(s, active.id, it.id))} className="w-6 h-6"/>
+                <span className={`flex-1 ${it.done? 'line-through text-slate-400':'text-slate-100'}`}>{it.text}</span>
+                <button onClick={()=> setState(s=>removeItem(s, active.id, it.id))} className="px-2 py-1 text-sm bg-rose-600 rounded text-white">Delete</button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Footer actions */}
+      <div className="flex justify-between mt-3">
+        <button onClick={()=> setState(s=>clearCompleted(s, active.id))} className="px-3 py-2 bg-amber-600 rounded text-white">Clear Completed</button>
+        {state.lists.length>1 && (
+          <button onClick={()=> setState(s=>removeList(s, active.id))} className="px-3 py-2 bg-rose-700 rounded text-white">Delete List</button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/src/widgets/Todo.tsx
+++ b/app/src/widgets/Todo.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { addItem, addList, clearCompleted, loadState, removeItem, removeList, renameList, saveState, setActive, toggleItem, type TodoState } from '../lib/todo'
+import { addItem, addList, clearCompleted, loadState, removeItem, removeList, saveState, setActive, toggleItem, type TodoState } from '../lib/todo'
 
 export default function TodoWidget() {
   const [state, setState] = React.useState<TodoState>(() => loadState())


### PR DESCRIPTION
Summary
- Adds a local-first To-do widget with multiple lists (tabs), add/toggle/delete items, and clear completed
- Persists state in localStorage; ships with default lists: Family and Groceries
- Integrates the widget into the dashboard grid

Details
- lib/todo.ts: Types (TodoItem, TodoList, TodoState) and pure helpers for load/save and state mutations
- widgets/Todo.tsx: UI with list tabs, add form, item list, actions
- App.tsx: imports and places the widget as a 2x2 tile alongside Weather and PhotoSlideshow

Usage
- Open the dashboard, switch lists via tabs, add tasks using the input field
- Data is stored in localStorage under key fam-bam-todo

Notes
- No external APIs; works offline
- Tailwind build currently requires @tailwindcss/postcss when building for production; dev server works fine. We can address this in a subsequent PR if desired.

Future
- Editing item text, reordering via drag & drop, filters (Today/This week), optional Google Tasks sync


@ajwilson79 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4f103c62bc394b15b88b6e8286dc2899)