### PR TITLE
feat: add runtime Settings panel (Weather, Calendar, Slideshow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,20 @@ Fam Bam Dash is a customizable, touch-friendly smart home dashboard designed to 
 
 🎯 Goal
 To create a self-hosted family dashboard that can be deployed in a Docker container and displayed full-screen in a browser—perfect for a hallway, kitchen, or living room screen.
+
+## Settings and Persistence
+- Runtime settings are editable via the Settings button in the app header.
+- Settings are persisted in localStorage under key: fam-bam-settings
+  - Weather: latitude, longitude
+  - Calendar: calendarId, maxEvents
+  - Slideshow: intervalMs, shuffle, useGooglePhotos
+- To-do lists persist under localStorage key: fam-bam-todo
+
+Defaults
+- Defaults are derived from build-time env where applicable (VITE_LAT, VITE_LON, VITE_GCAL_CALENDAR_ID, VITE_GOOGLE_PHOTOS_ALBUM_ID)
+- If env values are not provided, reasonable fallbacks are used
+
+Notes
+- Google Calendar requires VITE_GCAL_API_KEY and a calendarId (can be set at runtime in Settings)
+- Google Photos is optional. If enabled in Settings, it requires VITE_GOOGLE_CLIENT_ID and VITE_GOOGLE_PHOTOS_ALBUM_ID env vars and a one-time user consent prompt in the browser
+

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,17 +1,20 @@
 import './index.css'
 import Calendar from './widgets/Calendar'
-
 import Weather from './widgets/Weather'
 import PhotoSlideshow from './widgets/PhotoSlideshow'
 import Todo from './widgets/Todo'
-
+import SettingsPanel from './widgets/SettingsPanel'
+import React from 'react'
 
 function App() {
+  const [openSettings, setOpenSettings] = React.useState(false)
+
   return (
     <div className="min-h-screen bg-slate-900 text-white">
       <div className="grid grid-cols-4 grid-rows-4 gap-4 p-4">
-        <div className="col-span-2 row-span-1 bg-slate-800 rounded-xl p-4 flex items-center justify-center">
+        <div className="col-span-2 row-span-1 bg-slate-800 rounded-xl p-4 flex items-center justify-between">
           <h1 className="text-4xl font-semibold">Fam Bam Dash</h1>
+          <button onClick={()=>setOpenSettings(true)} className="px-3 py-2 rounded bg-slate-700">Settings</button>
         </div>
         <div className="col-span-2 row-span-2 bg-slate-800 rounded-xl p-4 flex items-center justify-center">
           <Clock />
@@ -29,11 +32,10 @@ function App() {
           <Calendar />
         </div>
       </div>
+      <SettingsPanel open={openSettings} onClose={()=>setOpenSettings(false)} />
     </div>
   )
 }
-
-import React from 'react'
 
 function Clock() {
   const [now, setNow] = React.useState(new Date())

--- a/app/src/lib/gcal.ts
+++ b/app/src/lib/gcal.ts
@@ -17,8 +17,10 @@ export function getEnvGCal() {
 export async function fetchUpcomingEvents({
   maxResults = 10,
   windowDays = 30,
-}: { maxResults?: number; windowDays?: number } = {}): Promise<GCalEvent[]> {
-  const { key, calendarId } = getEnvGCal()
+  calendarId: calendarIdOverride,
+}: { maxResults?: number; windowDays?: number; calendarId?: string } = {}): Promise<GCalEvent[]> {
+  const { key, calendarId: envCalendarId } = getEnvGCal()
+  const calendarId = calendarIdOverride || envCalendarId
   const now = new Date()
   const timeMin = now.toISOString()
   const timeMax = new Date(now.getTime() + windowDays * 24 * 60 * 60 * 1000).toISOString()

--- a/app/src/lib/photos.ts
+++ b/app/src/lib/photos.ts
@@ -7,7 +7,8 @@ export type PhotoItem = {
 export function loadLocalPhotos(): PhotoItem[] {
   const modules = import.meta.glob('../assets/photos/**/*.{jpg,jpeg,png,gif,webp,avif}', {
     eager: true,
-    as: 'url',
+    query: '?url',
+    import: 'default',
   }) as Record<string, string>
   const items = Object.entries(modules).map(([path, url], idx) => ({
     id: `local-${idx}-${path}`,

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -1,0 +1,32 @@
+export type Settings = {
+  weather: { lat: number; lon: number }
+  calendar: { calendarId: string; maxEvents: number }
+  slideshow: { intervalMs: number; shuffle: boolean; useGooglePhotos: boolean }
+}
+
+const KEY = 'fam-bam-settings'
+
+export function defaultSettings(): Settings {
+  return {
+    weather: { lat: Number(import.meta.env.VITE_LAT) || 37.7749, lon: Number(import.meta.env.VITE_LON) || -122.4194 },
+    calendar: { calendarId: String(import.meta.env.VITE_GCAL_CALENDAR_ID || ''), maxEvents: 10 },
+    slideshow: { intervalMs: 12000, shuffle: true, useGooglePhotos: !!import.meta.env.VITE_GOOGLE_PHOTOS_ALBUM_ID },
+  }
+}
+
+export function loadSettings(): Settings {
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (!raw) return defaultSettings()
+    const parsed = JSON.parse(raw)
+    return { ...defaultSettings(), ...parsed }
+  } catch {
+    return defaultSettings()
+  }
+}
+
+export function saveSettings(s: Settings) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(s))
+  } catch {}
+}

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -25,8 +25,19 @@ export function loadSettings(): Settings {
   }
 }
 
-export function saveSettings(s: Settings) {
+// simple pub/sub for settings changes
+const listeners = new Set<() => void>()
+export function subscribeSettings(fn: () => void) {
+  listeners.add(fn)
+  return () => listeners.delete(fn)
+}
+
+export function setSettings(s: Settings) {
   try {
     localStorage.setItem(KEY, JSON.stringify(s))
-  } catch {}
+  } finally {
+    listeners.forEach((fn) => {
+      try { fn() } catch {}
+    })
+  }
 }

--- a/app/src/widgets/Calendar.tsx
+++ b/app/src/widgets/Calendar.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { fetchUpcomingEvents, formatEventTime, type GCalEvent } from '../lib/gcal'
-import { loadSettings } from '../lib/settings'
+import { loadSettings, subscribeSettings } from '../lib/settings'
 
 export default function Calendar() {
   const [events, setEvents] = React.useState<GCalEvent[] | null>(null)
@@ -19,9 +19,11 @@ export default function Calendar() {
     }
     load()
     const id = setInterval(load, 15 * 60 * 1000)
+    const unsub = subscribeSettings(() => load())
     return () => {
       mounted = false
       clearInterval(id)
+      unsub()
     }
   }, [])
 

--- a/app/src/widgets/Calendar.tsx
+++ b/app/src/widgets/Calendar.tsx
@@ -11,7 +11,7 @@ export default function Calendar() {
     async function load() {
       try {
         const s = loadSettings()
-        const evs = await fetchUpcomingEvents({ maxResults: s.calendar.maxEvents, windowDays: 60 })
+        const evs = await fetchUpcomingEvents({ calendarId: s.calendar.calendarId, maxResults: s.calendar.maxEvents, windowDays: 60 })
         if (mounted) setEvents(evs)
       } catch (e: any) {
         if (mounted) setError(e?.message || 'Calendar failed')

--- a/app/src/widgets/Calendar.tsx
+++ b/app/src/widgets/Calendar.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { fetchUpcomingEvents, formatEventTime, type GCalEvent } from '../lib/gcal'
+import { loadSettings } from '../lib/settings'
 
 export default function Calendar() {
   const [events, setEvents] = React.useState<GCalEvent[] | null>(null)
@@ -9,7 +10,8 @@ export default function Calendar() {
     let mounted = true
     async function load() {
       try {
-        const evs = await fetchUpcomingEvents({ maxResults: 10, windowDays: 60 })
+        const s = loadSettings()
+        const evs = await fetchUpcomingEvents({ maxResults: s.calendar.maxEvents, windowDays: 60 })
         if (mounted) setEvents(evs)
       } catch (e: any) {
         if (mounted) setError(e?.message || 'Calendar failed')

--- a/app/src/widgets/PhotoSlideshow.tsx
+++ b/app/src/widgets/PhotoSlideshow.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { fetchGooglePhotosAlbum, getGooglePhotosToken, loadLocalPhotos, shuffle, type PhotoItem } from '../lib/photos'
+import { loadSettings } from '../lib/settings'
 
 function useLocalAndGooglePhotos() {
   const [photos, setPhotos] = React.useState<PhotoItem[]>([])
@@ -11,9 +12,10 @@ function useLocalAndGooglePhotos() {
       try {
         const local = loadLocalPhotos()
         let merged = local
+        const s = loadSettings()
         const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID as string | undefined
         const albumId = import.meta.env.VITE_GOOGLE_PHOTOS_ALBUM_ID as string | undefined
-        if (clientId && albumId) {
+        if (s.slideshow.useGooglePhotos && clientId && albumId) {
           try {
             const token = await getGooglePhotosToken(clientId)
             const remote = await fetchGooglePhotosAlbum(token, albumId, 200)
@@ -37,19 +39,23 @@ function useLocalAndGooglePhotos() {
   return { photos, error }
 }
 
-export default function PhotoSlideshow({ intervalMs = 12000, fadeMs = 800, shuffleOn = true }: { intervalMs?: number; fadeMs?: number; shuffleOn?: boolean }) {
+export default function PhotoSlideshow({ intervalMs, fadeMs = 800, shuffleOn }: { intervalMs?: number; fadeMs?: number; shuffleOn?: boolean }) {
   const { photos, error } = useLocalAndGooglePhotos()
   const [index, setIndex] = React.useState(0)
   const [ready, setReady] = React.useState(false)
 
-  const list = React.useMemo(() => (shuffleOn ? shuffle(photos) : photos), [photos, shuffleOn])
+  const s = loadSettings()
+  const effectiveInterval = intervalMs ?? s.slideshow.intervalMs
+  const effectiveShuffle = shuffleOn ?? s.slideshow.shuffle
+
+  const list = React.useMemo(() => (effectiveShuffle ? shuffle(photos) : photos), [photos, effectiveShuffle])
 
   React.useEffect(() => {
     if (list.length === 0) return
     setReady(true)
-    const id = setInterval(() => setIndex((i) => (i + 1) % list.length), intervalMs)
+    const id = setInterval(() => setIndex((i) => (i + 1) % list.length), effectiveInterval)
     return () => clearInterval(id)
-  }, [list, intervalMs])
+  }, [list, effectiveInterval])
 
   if (error) return <div className="text-red-400">{error}</div>
   if (!ready || list.length === 0) return <div className="text-slate-300">Add images under src/assets/photos</div>

--- a/app/src/widgets/PhotoSlideshow.tsx
+++ b/app/src/widgets/PhotoSlideshow.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { fetchGooglePhotosAlbum, getGooglePhotosToken, loadLocalPhotos, shuffle, type PhotoItem } from '../lib/photos'
-import { loadSettings } from '../lib/settings'
+import { loadSettings, subscribeSettings } from '../lib/settings'
 
 function useLocalAndGooglePhotos() {
   const [photos, setPhotos] = React.useState<PhotoItem[]>([])
@@ -30,9 +30,10 @@ function useLocalAndGooglePhotos() {
       }
     }
     load()
-    // No interval by default; photos are mostly static. Could add refresh later.
+    const unsub = subscribeSettings(() => load())
     return () => {
       mounted = false
+      unsub()
     }
   }, [])
 

--- a/app/src/widgets/SettingsPanel.tsx
+++ b/app/src/widgets/SettingsPanel.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { defaultSettings, loadSettings, saveSettings, type Settings } from '../lib/settings'
+
+export default function SettingsPanel({ open, onClose }: { open: boolean; onClose: ()=>void }) {
+  const [s, setS] = React.useState<Settings>(() => loadSettings())
+
+  React.useEffect(() => { saveSettings(s) }, [s])
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+      <div className="w-[90vw] max-w-2xl bg-slate-800 rounded-xl p-4 shadow-xl">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-xl font-semibold">Settings</h2>
+          <button onClick={onClose} className="px-3 py-1 rounded bg-slate-700">Close</button>
+        </div>
+
+        <div className="space-y-6">
+          {/* Weather */}
+          <section>
+            <h3 className="font-semibold mb-2">Weather</h3>
+            <div className="grid grid-cols-2 gap-3">
+              <label className="flex flex-col">
+                <span className="text-sm text-slate-300">Latitude</span>
+                <input type="number" step="0.0001" value={s.weather.lat} onChange={e=>setS(v=>({...v, weather:{...v.weather, lat:Number(e.target.value)}}))} className="bg-slate-900 border border-slate-700 rounded px-2 py-1"/>
+              </label>
+              <label className="flex flex-col">
+                <span className="text-sm text-slate-300">Longitude</span>
+                <input type="number" step="0.0001" value={s.weather.lon} onChange={e=>setS(v=>({...v, weather:{...v.weather, lon:Number(e.target.value)}}))} className="bg-slate-900 border border-slate-700 rounded px-2 py-1"/>
+              </label>
+            </div>
+          </section>
+
+          {/* Calendar */}
+          <section>
+            <h3 className="font-semibold mb-2">Google Calendar</h3>
+            <div className="grid grid-cols-2 gap-3">
+              <label className="flex flex-col col-span-2">
+                <span className="text-sm text-slate-300">Calendar ID</span>
+                <input value={s.calendar.calendarId} onChange={e=>setS(v=>({...v, calendar:{...v.calendar, calendarId:e.target.value}}))} className="bg-slate-900 border border-slate-700 rounded px-2 py-1"/>
+              </label>
+              <label className="flex flex-col">
+                <span className="text-sm text-slate-300">Max Events</span>
+                <input type="number" min={1} max={50} value={s.calendar.maxEvents} onChange={e=>setS(v=>({...v, calendar:{...v.calendar, maxEvents:Number(e.target.value)}}))} className="bg-slate-900 border border-slate-700 rounded px-2 py-1"/>
+              </label>
+            </div>
+          </section>
+
+          {/* Slideshow */}
+          <section>
+            <h3 className="font-semibold mb-2">Photo Slideshow</h3>
+            <div className="grid grid-cols-2 gap-3 items-center">
+              <label className="flex items-center gap-2">
+                <input type="checkbox" checked={s.slideshow.shuffle} onChange={e=>setS(v=>({...v, slideshow:{...v.slideshow, shuffle:e.target.checked}}))}/>
+                <span>Shuffle</span>
+              </label>
+              <label className="flex items-center gap-2">
+                <input type="checkbox" checked={s.slideshow.useGooglePhotos} onChange={e=>setS(v=>({...v, slideshow:{...v.slideshow, useGooglePhotos:e.target.checked}}))}/>
+                <span>Use Google Photos (requires env & consent)</span>
+              </label>
+              <label className="flex flex-col col-span-2">
+                <span className="text-sm text-slate-300">Interval (ms)</span>
+                <input type="number" min={3000} step={1000} value={s.slideshow.intervalMs} onChange={e=>setS(v=>({...v, slideshow:{...v.slideshow, intervalMs:Number(e.target.value)}}))} className="bg-slate-900 border border-slate-700 rounded px-2 py-1"/>
+              </label>
+            </div>
+          </section>
+
+          <div className="flex gap-3">
+            <button onClick={()=>setS(defaultSettings())} className="px-3 py-2 rounded bg-slate-700">Reset to defaults</button>
+            <button onClick={()=>{
+              const data = JSON.stringify(s, null, 2)
+              const blob = new Blob([data], { type: 'application/json' })
+              const url = URL.createObjectURL(blob)
+              const a = document.createElement('a')
+              a.href = url
+              a.download = 'fam-bam-settings.json'
+              a.click()
+              URL.revokeObjectURL(url)
+            }} className="px-3 py-2 rounded bg-slate-700">Export JSON</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/widgets/SettingsPanel.tsx
+++ b/app/src/widgets/SettingsPanel.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { defaultSettings, loadSettings, saveSettings, type Settings } from '../lib/settings'
+import { defaultSettings, loadSettings, setSettings, type Settings } from '../lib/settings'
 
 export default function SettingsPanel({ open, onClose }: { open: boolean; onClose: ()=>void }) {
   const [s, setS] = React.useState<Settings>(() => loadSettings())
 
-  React.useEffect(() => { saveSettings(s) }, [s])
+  React.useEffect(() => { setSettings(s) }, [s])
 
   if (!open) return null
 

--- a/app/src/widgets/Weather.tsx
+++ b/app/src/widgets/Weather.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { codeToIcon, fetchWeather, getEnvCoords, type WeatherData } from '../lib/weather'
+import { codeToIcon, fetchWeather, type WeatherData } from '../lib/weather'
+import { loadSettings } from '../lib/settings'
 
 export default function Weather() {
   const [data, setData] = React.useState<WeatherData | null>(null)
@@ -9,8 +10,8 @@ export default function Weather() {
     let mounted = true
     async function load() {
       try {
-        const { lat, lon } = getEnvCoords()
-        const w = await fetchWeather(lat, lon)
+        const s = loadSettings()
+        const w = await fetchWeather(s.weather.lat, s.weather.lon)
         if (mounted) setData(w)
       } catch (e: any) {
         if (mounted) setError(e?.message || 'Weather failed')

--- a/app/src/widgets/Weather.tsx
+++ b/app/src/widgets/Weather.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { codeToIcon, fetchWeather, type WeatherData } from '../lib/weather'
-import { loadSettings } from '../lib/settings'
+import { loadSettings, subscribeSettings } from '../lib/settings'
 
 export default function Weather() {
   const [data, setData] = React.useState<WeatherData | null>(null)
@@ -19,9 +19,11 @@ export default function Weather() {
     }
     load()
     const id = setInterval(load, 15 * 60 * 1000) // refresh every 15 min
+    const unsub = subscribeSettings(() => load())
     return () => {
       mounted = false
       clearInterval(id)
+      unsub()
     }
   }, [])
 


### PR DESCRIPTION
Summary
- Adds a Settings panel for adjusting Weather, Google Calendar, and Photo Slideshow behavior at runtime
- Persists settings to localStorage; sensible defaults derive from build-time env

Details
- lib/settings.ts: defaultSettings(), loadSettings(), saveSettings(); stored under fam-bam-settings
- widgets/SettingsPanel.tsx: Modal with inputs for lat/lon, calendarId+maxEvents, slideshow interval/shuffle/google
- Weather.tsx: reads lat/lon from settings
- Calendar.tsx: reads maxEvents from settings
- PhotoSlideshow.tsx: uses interval and shuffle; toggle Google Photos usage
- App.tsx: adds Settings button and integrates modal

Verification
- npm run build succeeds locally; functionality works in dev
- Note: Vite deprecation warning for import.meta.glob as:url remains (non-blocking)

Next
- Optional: handle live reactivity to settings changes (now reads at load time)
- Optional: update glob usage to new query format


@ajwilson79 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4f103c62bc394b15b88b6e8286dc2899)