### PR TITLE
chore(vite): migrate import.meta.glob to new query format (?url) for Photos loader

### DIFF
--- a/app/src/lib/photos.ts
+++ b/app/src/lib/photos.ts
@@ -7,7 +7,8 @@ export type PhotoItem = {
 export function loadLocalPhotos(): PhotoItem[] {
   const modules = import.meta.glob('../assets/photos/**/*.{jpg,jpeg,png,gif,webp,avif}', {
     eager: true,
-    as: 'url',
+    query: '?url',
+    import: 'default',
   }) as Record<string, string>
   const items = Object.entries(modules).map(([path, url], idx) => ({
     id: `local-${idx}-${path}`,


### PR DESCRIPTION
Summary
- Updates import.meta.glob usage to use the new query format (query: '?url', import: 'default')
- Removes Vite deprecation warning emitted during build

Details
- app/src/lib/photos.ts: replace deprecated `as: 'url'` with `query: '?url'` and `import: 'default'`

Verification
- npm run build completes successfully with no deprecation warning

Notes
- No runtime behavior changes; only build-time cleanup

@ajwilson79 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4f103c62bc394b15b88b6e8286dc2899)